### PR TITLE
Added image content copying for PNGs (SVGs unsupported at least for now)

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -19,6 +19,13 @@ contextBridge.exposeInMainWorld("fsAPI", {
       return [];
     }
   },
+  copyImageToClipboard: async (imageUrl) => {
+    try {
+      return await ipcRenderer.invoke("copyImageToClipboard", imageUrl);
+    } catch (error) {
+      return false;
+    }
+  },
 });
 
 contextBridge.exposeInMainWorld("tagAPI", {

--- a/src/components/DirectoriesSidebar.vue
+++ b/src/components/DirectoriesSidebar.vue
@@ -13,7 +13,6 @@
 
 <script setup>
 import SidebarItem from "./SidebarItem.vue";
-import { defineEmits, defineProps } from "vue";
 
 const emit = defineEmits(["directory-selected"]);
 

--- a/src/components/IconDetails.vue
+++ b/src/components/IconDetails.vue
@@ -7,6 +7,14 @@
       @click="showEnlargedImage"
       style="cursor: zoom-in"
     />
+    <img
+      v-if="canCopyImageType"
+      src="../assets/clipboard.svg"
+      width="20px"
+      alt="Copy"
+      style="cursor: pointer"
+      @click="copyImageToClipboard(item.url)"
+    />
   </div>
   <div class="details">
     <div class="details-row">
@@ -94,6 +102,11 @@ const props = defineProps({
   },
 });
 
+const canCopyImageType = computed(() => {
+  const copyableTypes = new Set([".png"]); // More should be supportd in the future
+  return copyableTypes.has(props.item.extension);
+});
+
 const path = computed(() => {
   return props.item.parentPath
     ? `${props.item.parentPath}/${props.item.name}`
@@ -123,6 +136,15 @@ const addTagClicked = () => {
 
 const showEnlargedImage = () => {
   emit("enlarge-image", props.item.url);
+};
+
+const copyImageToClipboard = async (imageUrl) => {
+  let success = await window.fsAPI.copyImageToClipboard(imageUrl);
+  if (success) {
+    console.log("Copied icon to clipboard:", imageUrl);
+  } else {
+    console.error("Error: Could not copy icon to clipboard:", imageUrl);
+  }
 };
 </script>
 


### PR DESCRIPTION
Added image content copying for PNGs (SVGs unsupported at least for now because they don't work with Electron's `writeImage`).

Copy button is only visible for compatible types which is only PNG right now but should be expanded as more types are supported by the app in general.

Closes #14 